### PR TITLE
Switch to 2018 edition, code cosmetics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ matrix:
         - rustup component add rustfmt
       script:
         - cargo fmt -v -- --check
+    - name: "Rust: clippy"
+      rust: stable
+      install:
+        - rustup component add clippy
+      script:
+        - cargo clippy --all-features --all-targets -- -D warnings
 
 env:
   - RUST_TEST_THREADS=1 RUST_TEST_TASKS=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["maildir", "email", "rfc822", "mime"]
 categories = ["email", "filesystem"]
 license = "0BSD"
 exclude = ["target/doc/**", ".gitattributes"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "staktrace/maildir", branch = "master" }

--- a/examples/explain.rs
+++ b/examples/explain.rs
@@ -1,5 +1,3 @@
-extern crate maildir;
-
 use maildir::MailEntry;
 use maildir::Maildir;
 use std::path::PathBuf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ impl error::Error for MailEntryError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             MailEntryError::IOError(ref err) => Some(err),
             MailEntryError::ParseError(ref err) => Some(err),
@@ -266,7 +266,7 @@ impl error::Error for MaildirError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         use MaildirError::*;
 
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate mailparse;
-extern crate nix;
-
 use std::error;
 use std::fmt;
 use std::fs;


### PR DESCRIPTION
This modernizes the code a bit (no `try!`, no `extern
crate`). Regarding the clippy warning fixes: I have fixed all
warnings; please tell me if some warnings should not be fixed and thus
disabled, and I'll add the required `#[allow]` attributes.

This is a follow-up PR to #7; I'll rebase it if/when that goes in -- please ignore the commit introduced by PR #7 for the purposes of reviewing this PR.