### PR TITLE
 store_new and store_cur_with_flags now return the id of the inserted mail

### DIFF
--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -167,8 +167,18 @@ fn check_store_new() {
         maildir.create_dirs().unwrap();
 
         assert_eq!(maildir.count_new(), 0);
-        maildir.store_new(TEST_MAIL_BODY).unwrap();
+        let id = maildir.store_new(TEST_MAIL_BODY);
+        assert!(id.is_ok());
         assert_eq!(maildir.count_new(), 1);
+
+        let id = id.unwrap();
+        let msg = maildir.find(&id);
+        assert!(msg.is_some());
+
+        assert_eq!(
+            msg.unwrap().parsed().unwrap().get_body_raw().unwrap(),
+            "Today is Boomtime, the 59th day of Discord in the YOLD 3183".as_bytes()
+        );
     });
 }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -143,23 +143,23 @@ fn check_create_dirs() {
 }
 
 const TEST_MAIL_BODY: &[u8] = b"Return-Path: <of82ecuq@cip.cs.fau.de>
-iginal-To: of82ecuq@cip.cs.fau.de
-vered-To: of82ecuq@cip.cs.fau.de
-ived: from faui0fl.informatik.uni-erlangen.de (unknown [IPv6:2001:638:a000:4160:131:188:60:117])
-    by faui03.informatik.uni-erlangen.de (Postfix) with ESMTP id 466C1240A3D
-    for <of82ecuq@cip.cs.fau.de>; Fri, 12 May 2017 10:09:45 +0000 (UTC)
-ived: by faui0fl.informatik.uni-erlangen.de (Postfix, from userid 303135)
-    id 389CC10E1A32; Fri, 12 May 2017 12:09:45 +0200 (CEST)
-of82ecuq@cip.cs.fau.de
--Version: 1.0
-ent-Type: text/plain; charset=\"UTF-8\"
-ent-Transfer-Encoding: 8bit
-age-Id: <20170512100945.389CC10E1A32@faui0fl.informatik.uni-erlangen.de>
-: Fri, 12 May 2017 12:09:45 +0200 (CEST)
-: of82ecuq@cip.cs.fau.de (Johannes Schilling)
-ect: maildir delivery test mail
+X-Original-To: of82ecuq@cip.cs.fau.de
+Delivered-To: of82ecuq@cip.cs.fau.de
+Received: from faui0fl.informatik.uni-erlangen.de (unknown [IPv6:2001:638:a000:4160:131:188:60:117])
+        by faui03.informatik.uni-erlangen.de (Postfix) with ESMTP id 466C1240A3D
+        for <of82ecuq@cip.cs.fau.de>; Fri, 12 May 2017 10:09:45 +0000 (UTC)
+Received: by faui0fl.informatik.uni-erlangen.de (Postfix, from userid 303135)
+        id 389CC10E1A32; Fri, 12 May 2017 12:09:45 +0200 (CEST)
+To: of82ecuq@cip.cs.fau.de
+MIME-Version: 1.0
+Content-Type: text/plain; charset=\"UTF-8\"
+Content-Transfer-Encoding: 8bit
+Message-Id: <20170512100945.389CC10E1A32@faui0fl.informatik.uni-erlangen.de>
+Date: Fri, 12 May 2017 12:09:45 +0200 (CEST)
+From: of82ecuq@cip.cs.fau.de (Johannes Schilling)
+Subject: maildir delivery test mail
 
-y is Boomtime, the 59th day of Discord in the YOLD 3183";
+Today is Boomtime, the 59th day of Discord in the YOLD 3183";
 
 #[test]
 fn check_store_new() {


### PR DESCRIPTION
This addresses a part of #12.

Previously there was no trivial way how one could get the `id` of a freshly inserted email. The first commit of this PR modifies the return type of `Maildir::store` to `Result<String, MaildirError>`, and returns the id on success.

The smoke test for `store_new` was modified to verify that the id is actually the correct one.

I've also discovered that in 3ace2c97e8eeaba3bd36d6b371d00850790bdd4e `TEST_MAIL_BODY` was incorrectly copied (the first characters of each line are missing). I've restored the original state of this string, as otherwise `mailparse` cannot parse the email.


I am not sure whether returning a String from `Maildir::store` is the correct approach here, so I'd be more than happy to change it to something more suitable.