### PR TITLE
Switch to memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 mailparse = "0.13"
 gethostname = "0.2.1"
-memmap = { version = "0.7.0", optional = true }
+memmap2 = { version = "0.5.7", optional = true }
 
 [features]
-mmap = ["memmap"]
+mmap = ["memmap2"]
 
 [dev-dependencies]
 tempfile = "3.0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "mmap")]
-extern crate memmap;
+extern crate memmap2;
 
 use std::error;
 use std::fmt;
@@ -70,7 +70,7 @@ enum MailData {
     #[cfg(not(feature = "mmap"))]
     Bytes(Vec<u8>),
     #[cfg(feature = "mmap")]
-    File(memmap::Mmap),
+    File(memmap2::Mmap),
 }
 
 impl MailData {
@@ -104,7 +104,7 @@ impl MailEntry {
             #[cfg(feature = "mmap")]
             {
                 let f = fs::File::open(&self.path)?;
-                let mmap = unsafe { memmap::MmapOptions::new().map(&f)? };
+                let mmap = unsafe { memmap2::MmapOptions::new().map(&f)? };
                 self.data = MailData::File(mmap);
             }
 


### PR DESCRIPTION
This would resolve that maildir uses the unmaintained memmap crate (see https://github.com/danburkert/memmap-rs/issues/90 and #30 ) and switches to a maintained fork https://github.com/RazrFalcon/memmap2-rs

Feature wise the crates seem to do mostly the same while the newer one could eventually have benefits. This PR however only switches over and should behave the same. 

Notable changes are:

- winapi dependency was removed
- A integer overflow had been fixed on 32bit targets https://github.com/danburkert/memmap-rs/commit/9aa838aed99a4879d8357ff295a0ca1c98ba1ae5
- tempdir crate got replaced with the tempfile crate

A full list of changes is at https://github.com/danburkert/memmap-rs/compare/master...RazrFalcon:memmap2-rs:master