### PR TITLE
CHG: honor src subfolder when copying or moving mail to other Maildir

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,23 @@ impl Maildir {
         let entry = self.find(id).ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::NotFound, "Mail entry not found")
         })?;
-        let filename = entry.path().file_name().ok_or_else(|| {
+        let filepath = entry.path();
+        let folder = filepath
+            .parent()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid mail dir structure",
+                )
+            })?
+            .file_name().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid mail dir structure",
+                )
+            })?;
+
+        let filename = filepath.file_name().ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "Invalid mail entry file name",
@@ -524,7 +540,7 @@ impl Maildir {
         })?;
 
         let src_path = entry.path();
-        let dst_path = target.path().join("cur").join(filename);
+        let dst_path = target.path().join(folder).join(filename);
         if src_path == &dst_path {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -541,13 +557,29 @@ impl Maildir {
         let entry = self.find(id).ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::NotFound, "Mail entry not found")
         })?;
-        let filename = entry.path().file_name().ok_or_else(|| {
+        let filepath = entry.path();
+        let folder = filepath
+            .parent()
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid mail dir structure",
+                )
+            })?
+            .file_name().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid mail dir structure",
+                )
+            })?;
+
+        let filename = filepath.file_name().ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "Invalid mail entry file name",
             )
         })?;
-        fs::rename(entry.path(), target.path().join("cur").join(filename))?;
+        fs::rename(entry.path(), target.path().join(folder).join(filename))?;
         Ok(())
     }
 


### PR DESCRIPTION
Hello,

I am currently working on a small rust program which is basically a bridge between two MailDirs with some additional magic.

In my program, I basically do something like this:

    let mut maildir_in = Maildir::from("/testpath1");
    let mut maildir_out = Maildir::from("/testpath2");
    
    for mail in maildir_in.list_new() {
        match mail {
            Ok(mail_entry) => {
                let _ = maildir_in.move_to(mail_entry.id(), &maildir_out);
            },
            Err(e) => {
                eprintln!("{}", e);
                continue;
            }
        };
    }

This works but to my surprise, the mails ended up in the cur folder, not the new folder of maildir_out.
Investigating the source code made clear why, mails were always moved into "cur" independent from the folder they came from. With this change, the parent folder is honored and this a mail moved from new will end up in new and a mail moved or copied from cur will end up in cur.

[EDIT]
Messed up the code block so I had to fix the highlighting