### PR TITLE
Preserve the subfolder when copying/moving messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,18 +519,18 @@ impl Maildir {
 
     /// Copies a message from the current maildir to the targetted maildir.
     pub fn copy_to(&self, id: &str, target: &Maildir) -> std::io::Result<()> {
-        let entry = self.find(id).ok_or_else(|| {
+        let entry = self.find_folder(id).ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::NotFound, "Mail entry not found")
         })?;
-        let filename = entry.path().file_name().ok_or_else(|| {
+        let filename = entry.0.path().file_name().ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "Invalid mail entry file name",
             )
         })?;
 
-        let src_path = entry.path();
-        let dst_path = target.path().join("cur").join(filename);
+        let src_path = entry.0.path();
+        let dst_path = target.path().join(entry.1.to_str()).join(filename);
         if src_path == &dst_path {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -544,16 +544,19 @@ impl Maildir {
 
     /// Moves a message from the current maildir to the targetted maildir.
     pub fn move_to(&self, id: &str, target: &Maildir) -> std::io::Result<()> {
-        let entry = self.find(id).ok_or_else(|| {
+        let entry = self.find_folder(id).ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::NotFound, "Mail entry not found")
         })?;
-        let filename = entry.path().file_name().ok_or_else(|| {
+        let filename = entry.0.path().file_name().ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "Invalid mail entry file name",
             )
         })?;
-        fs::rename(entry.path(), target.path().join("cur").join(filename))?;
+        fs::rename(
+            entry.0.path(),
+            target.path().join(entry.1.to_str()).join(filename),
+        )?;
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ impl MailEntry {
         Ok(())
     }
 
-    pub fn parsed(&mut self) -> Result<ParsedMail, MailEntryError> {
+    pub fn parsed(&mut self) -> Result<ParsedMail<'_>, MailEntryError> {
         self.read_data()?;
         match self.data {
             MailData::None => panic!("read_data should have returned an Err!"),
@@ -157,7 +157,7 @@ impl MailEntry {
         }
     }
 
-    pub fn headers(&mut self) -> Result<Vec<MailHeader>, MailEntryError> {
+    pub fn headers(&mut self) -> Result<Vec<MailHeader<'_>>, MailEntryError> {
         self.read_data()?;
         let headers = match self.data {
             MailData::None => panic!("read_data should have returned an Err!"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,15 @@ enum Subfolder {
     Cur,
 }
 
+impl Subfolder {
+    fn to_str(&self) -> &str {
+        match &self {
+            Subfolder::New => "new",
+            Subfolder::Cur => "cur",
+        }
+    }
+}
+
 /// An iterator over the email messages in a particular
 /// maildir subfolder (either `cur` or `new`). This iterator
 /// produces a `std::io::Result<MailEntry>`, which can be an
@@ -262,10 +271,7 @@ impl Iterator for MailEntries {
     fn next(&mut self) -> Option<std::io::Result<MailEntry>> {
         if self.readdir.is_none() {
             let mut dir_path = self.path.clone();
-            dir_path.push(match self.subfolder {
-                Subfolder::New => "new",
-                Subfolder::Cur => "cur",
-            });
+            dir_path.push(self.subfolder.to_str());
             self.readdir = match fs::read_dir(dir_path) {
                 Err(_) => return None,
                 Ok(v) => Some(v),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,14 @@ impl Maildir {
     /// maildir. This searches both the `new` and the `cur`
     /// folders.
     pub fn find(&self, id: &str) -> Option<MailEntry> {
+        self.find_folder(id).map(|r| r.0)
+    }
+
+    /// Tries to find the message with the given id in the
+    /// maildir. This searches both the `new` and the `cur`
+    /// folders, and returns the MailEntry along with the
+    /// Subfolder it was found in, or None if not found.
+    pub(crate) fn find_folder(&self, id: &str) -> Option<(MailEntry, Subfolder)> {
         let filter = |entry: &std::io::Result<MailEntry>| match *entry {
             Err(_) => false,
             Ok(ref e) => e.id() == id,
@@ -568,8 +576,9 @@ impl Maildir {
 
         self.list_new()
             .find(&filter)
-            .or_else(|| self.list_cur().find(&filter))
-            .map(|e| e.unwrap())
+            .map(|m| (m, Subfolder::New))
+            .or_else(|| self.list_cur().find(&filter).map(|m| (m, Subfolder::Cur)))
+            .map(|(m, f)| (m.unwrap(), f))
     }
 
     fn normalize_flags(flags: &str) -> String {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -246,12 +246,25 @@ fn check_copy_and_move() {
             assert!(maildir.find(id).is_some());
             assert!(submaildir.find(id).is_some());
 
-            // move the message from "submaildir" to "maildir"
-            submaildir.move_to(id, &maildir).unwrap();
+            let new_id = "1463941010.5f7fa6dd4922c183dc457d033deee9d7";
+            // move a message from maildir's new subfolder to submaildir
+            maildir.move_to(new_id, &submaildir).unwrap();
 
-            // check that the message is now only present in "maildir"
-            assert!(maildir.find(id).is_some());
-            assert!(submaildir.find(id).is_none());
+            // check that the message is now only present in submaildir, in
+            // the new subfolder
+            assert!(submaildir.find(new_id).is_some());
+            assert_eq!(
+                submaildir
+                    .find(new_id)
+                    .unwrap()
+                    .path()
+                    .parent()
+                    .unwrap()
+                    .file_name()
+                    .unwrap(),
+                "new"
+            );
+            assert!(maildir.find(new_id).is_none());
         })
     })
 }


### PR DESCRIPTION
This is a reimplementation of the fix in #42 but more in line with my preferred style. The goal here is to preserve the subfolder when using the copy_to or move_to functions to copy/move messages from one `Maildir` to another. Previously it would always be copied/moved into the `cur` subfolder of the target maildir, but now it will be copied into either `new` or `cur` depending on where it was in the source maildir.

Note that this is a BREAKING CHANGE! Existing consumers of these APIs may need to additionally call `move_new_to_cur` on the target maildir if they were expecting a `new` message from one maildir to end up in the `cur` of the other (which was the previous behaviour of these APIs).