### PR TITLE
Implement store_new_with_flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,15 @@ impl Iterator for MailEntries {
                     return Ok(None);
                 }
                 let (id, flags) = match self.subfolder {
-                    Subfolder::New => (Some(filename.as_str()), Some("")),
+                    Subfolder::New => {
+                        let delim = format!("{}2,", INFORMATIONAL_SUFFIX_SEPARATOR);
+                        if filename.contains(delim.as_str()) {
+                            let mut iter = filename.split(&delim);
+                            (iter.next(), iter.next())
+                        } else {
+                            (Some(filename.as_str()), Some(""))
+                        }
+                    }
                     Subfolder::Cur => {
                         let delim = format!("{}2,", INFORMATIONAL_SUFFIX_SEPARATOR);
                         let mut iter = filename.split(&delim);
@@ -685,6 +693,27 @@ impl Maildir {
     /// Returns the Id of the inserted message on success.
     pub fn store_new(&self, data: &[u8]) -> std::result::Result<String, MaildirError> {
         self.store(Subfolder::New, data, "")
+    }
+
+    /// Stores the given message data as a new message file in the Maildir `new` folder, adding the
+    /// given `flags` to it. This is technically out of spec, but certain MDAs and MUAs depend on
+    /// this behavior. The possible flags are explained e.g. at
+    /// <https://cr.yp.to/proto/maildir.html> or <http://www.courier-mta.org/maildir.html>. Returns
+    /// the Id of the inserted message on success.
+    pub fn store_new_with_flags(
+        &self,
+        data: &[u8],
+        flags: &str,
+    ) -> std::result::Result<String, MaildirError> {
+        self.store(
+            Subfolder::New,
+            data,
+            &format!(
+                "{}2,{}",
+                INFORMATIONAL_SUFFIX_SEPARATOR,
+                Self::normalize_flags(flags)
+            ),
+        )
     }
 
     /// Stores the given message data as a new message file in the Maildir `cur` folder, adding the

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -334,6 +334,52 @@ fn check_store_new() {
 }
 
 #[test]
+fn check_store_new_with_flags() {
+    with_maildir_empty("maildir2", |maildir| {
+        maildir.create_dirs().unwrap();
+
+        assert_eq!(maildir.count_new(), 0);
+        let id = maildir.store_new_with_flags(TEST_MAIL_BODY, "F");
+        assert!(id.is_ok());
+        assert_eq!(maildir.count_new(), 1);
+
+        let id = id.unwrap();
+        let msg = maildir.find(&id);
+        assert!(msg.is_some());
+
+        assert_eq!(
+            msg.unwrap().parsed().unwrap().get_body_raw().unwrap(),
+            b"Today is Boomtime, the 59th day of Discord in the YOLD 3183".as_ref()
+        );
+    });
+}
+
+#[test]
+fn check_store_new_with_flags_coexist_with_store_new_without() {
+    with_maildir_empty("maildir2", |maildir| {
+        maildir.create_dirs().unwrap();
+
+        assert_eq!(maildir.count_new(), 0);
+        let id = maildir.store_new_with_flags(TEST_MAIL_BODY, "F");
+        assert!(id.is_ok());
+        assert_eq!(maildir.count_new(), 1);
+
+        let id = maildir.store_new(TEST_MAIL_BODY);
+        assert!(id.is_ok());
+        assert_eq!(maildir.count_new(), 2);
+
+        let id = id.unwrap();
+        let msg = maildir.find(&id);
+        assert!(msg.is_some());
+
+        assert_eq!(
+            msg.unwrap().parsed().unwrap().get_body_raw().unwrap(),
+            b"Today is Boomtime, the 59th day of Discord in the YOLD 3183".as_ref()
+        );
+    });
+}
+
+#[test]
 fn check_store_cur() {
     with_maildir_empty("maildir2", |maildir| {
         maildir.create_dirs().unwrap();


### PR DESCRIPTION
Some MDAs such as OfflineIMAP and mbsync need to preserve flags when fetching from an IMAP upstream; e.g. because a server-side mail filter has flagged an email beforehand. Additionally, some MUAs such as mutt, unless configured, will only ever check the new/ directory of a Maildir for new mail.

Because of this, if a user of this crate wants to ever support this use case they are forced to work around the crate by reimplementing store() themselves -- it's not safe to just call store_new() then rename the file themselves, as they may race a MUA: the MUA will see the bare file before the rename to add flags and move it to cur themselves.

Support this use case by providing a method to store mesages in new/ with flags, and to iterate messages with flags in new/.

Fixes #44.